### PR TITLE
docs: add sakuraba07 to authors in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "mdbook-typst-math"
 version = "0.1.1"
 edition = "2021"
-authors = ["duskmoon (Campbell He) <kp.campbell.he@duskmoon314.com>"]
+authors = [
+    "duskmoon (Campbell He) <kp.campbell.he@duskmoon314.com>",
+    "sakuraba07 <207140744+sakuraba07@users.noreply.github.com>",
+]
 description = "An mdbook preprocessor to use typst to render math."
 readme = "README.md"
 repository = "https://github.com/duskmoon314/mdbook-typst-math"


### PR DESCRIPTION
## Summary

Add sakuraba07 to the authors field in Cargo.toml as requested in #25.

## Changes

- Added sakuraba07 to the `authors` field in `Cargo.toml`
- Reformatted the `authors` array to multi-line for better readability
