### PR TITLE
docs: Add documentation for using Typst packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,41 @@ display_preamble = """
 #set text(size: 14pt)
 #show math.equation: set text(font: "Fira Math")
 """
+
+# Cache directory for downloaded packages
+#
+# If you want to use Typst packages (e.g., physica), you should set this.
+# The packages will be downloaded from packages.typst.org and cached here.
+cache = ".typst-cache"
 ````
+
+### Using Typst Packages
+
+This preprocessor supports Typst packages from [Typst Universe](https://typst.app/universe).
+Packages are automatically downloaded and cached when first used.
+
+To use a package like [physica](https://typst.app/universe/package/physica), add the import to your preamble:
+
+```toml
+[preprocessor.typst-math]
+cache = ".typst-cache"
+preamble = """
+#set page(width:auto, height:auto, margin:0.5em)
+#import "@preview/physica:0.9.3": *
+"""
+```
+
+Then you can use the package features in your math blocks:
+
+```markdown
+The derivative is $dv(f,x)$ and the partial derivative is $pdv(f,x,y)$.
+
+$$
+grad f = vu(x) pdv(f,x) + vu(y) pdv(f,y)
+$$
+```
+
+> **Note:** Make sure to set the `cache` option to specify where downloaded packages should be stored. You may want to add this directory to your `.gitignore`.
 
 ## TODO
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,1 +1,2 @@
 book
+.typst-cache

--- a/example/book.toml
+++ b/example/book.toml
@@ -5,9 +5,11 @@ src = "src"
 
 [preprocessor.typst-math]
 command = "../target/release/mdbook-typst-math"
+cache = ".typst-cache"
 preamble = """
 #set page(width: auto, height: auto, margin: 0.5em)
 #set text(size: 12pt)
+#import "@preview/physica:0.9.3": *
 """
 
 [output.html]

--- a/example/src/chapter_1.md
+++ b/example/src/chapter_1.md
@@ -25,3 +25,37 @@ This is a block example
 $$
 Q = rho A v + C
 $$
+
+---
+
+## Using Typst Packages
+
+You can use Typst packages by importing them in the `preamble` configuration.
+For example, to use the [physica](https://typst.app/universe/package/physica) package:
+
+```toml
+[preprocessor.typst-math]
+cache = ".typst-cache"
+preamble = """
+#set page(width: auto, height: auto, margin: 0.5em)
+#import "@preview/physica:0.9.3": *
+"""
+```
+
+Then you can use physica functions in your math blocks:
+
+```markdown
+Derivative: $dv(f, x)$, Partial derivative: $pdv(f, x, y)$
+```
+
+Derivative: $dv(f, x)$, Partial derivative: $pdv(f, x, y)$
+
+```markdown
+$$
+grad f = vu(x) pdv(f, x) + vu(y) pdv(f, y) + vu(z) pdv(f, z)
+$$
+```
+
+$$
+grad f = vu(x) pdv(f, x) + vu(y) pdv(f, y) + vu(z) pdv(f, z)
+$$


### PR DESCRIPTION
## Summary
Added documentation explaining how to use Typst packages (e.g., physica) with this preprocessor.

## Changes
- README.md: Added `cache` option documentation and "Using Typst Packages" section
- example/book.toml: Added physica package example
- example/src/chapter_1.md: Added usage examples with physica
- example/.gitignore: Added `.typst-cache`

## Motivation
The preprocessor already supports Typst packages, but this was not documented.
Users may not realize they can use packages like physica without reading the source code.
