### PR TITLE
fix: support single font file paths in fonts config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,18 @@ impl Preprocessor for TypstProcessor {
         // Load fonts from the config
         if let Some(fonts) = config.fonts {
             for font_path in fonts.into_vec() {
-                db.load_fonts_dir(font_path);
+                let path = std::path::Path::new(&font_path);
+                if path.is_file() {
+                    // Load single font file
+                    if let Err(e) = db.load_font_file(&font_path) {
+                        eprintln!("Warning: Failed to load font file {:?}: {}", font_path, e);
+                    }
+                } else if path.is_dir() {
+                    // Load all fonts from directory
+                    db.load_fonts_dir(&font_path);
+                } else {
+                    eprintln!("Warning: Font path does not exist: {:?}", font_path);
+                }
             }
         }
         // Load system fonts, lower priority


### PR DESCRIPTION
Previously, the fonts config only worked with directories because load_fonts_dir() was used unconditionally. This caused single font file paths (e.g., fonts = "/path/to/font.ttf") to be silently ignored.

Now the code checks whether the path is a file or directory and uses the appropriate fontdb function:
- load_font_file() for single files
- load_fonts_dir() for directories

Also adds a warning message when the specified font path does not exist.