### PR TITLE
Load discovered fonts lazily with typst-kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1651,7 +1651,6 @@ dependencies = [
  "clap",
  "codespan-reporting",
  "flate2",
- "fontdb",
  "mdbook-preprocessor",
  "pulldown-cmark",
  "reqwest",
@@ -1662,8 +1661,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "typst",
- "typst-assets",
  "typst-html",
+ "typst-kit",
  "typst-svg",
 ]
 
@@ -1731,7 +1730,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2133,7 +2132,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2374,7 +2373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2431,7 +2430,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3320,6 +3319,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "typst-kit"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31476ec753e080ffdd543a0e74b6d319355449ff3eca3f216634f31cfd09a92a"
+dependencies = [
+ "ecow",
+ "fontdb",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "typst-assets",
+ "typst-library",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
+]
+
+[[package]]
 name = "typst-layout"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3901,7 +3918,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ anyhow = "1.0.100"
 clap = { version = "4.5.54", features = ["derive"] }
 codespan-reporting = "0.13.1"
 flate2 = "1.1.8"
-fontdb = "0.23.0"
 mdbook-preprocessor = "0.5.2"
 pulldown-cmark = "0.13.0"
 reqwest = { version = "0.13.1", features = ["blocking"] }
@@ -38,12 +37,12 @@ time = { version = "0.3.45", features = ["local-offset"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 typst = "0.14.2"
-typst-assets = { version = "0.14.2", features = ["fonts"], optional = true }
 typst-html = "0.14.2"
+typst-kit = { version = "0.14.2", default-features = false, features = ["fonts"] }
 typst-svg = "0.14.2"
 
 [features]
 default = ["embed-fonts"]
 
-# Embed fonts from typst-assets
-embed-fonts = ["typst-assets"]
+# Embed Typst's fallback fonts through typst-kit's font slots.
+embed-fonts = ["typst-kit/embed-fonts"]

--- a/README.md
+++ b/README.md
@@ -216,15 +216,16 @@ $$
 Currently, only following configurations are supported. Here we use an example to show how to set them:
 
 ````toml
-[preprocessor.typst]
+[preprocessor.typst-math]
 
-# Additional fonts to load
-#
-# Two types are supported: a string or an array of strings
-#
-# Usually, you don't need to set this since the default build of preprocessor
-# will load system fonts and typst embedded fonts.
-fonts = ["/path/to/FiraMath-Regular.otf"] # or "/path/to/FiraMath-Regular.otf"
+# Additional font files or directories to load.
+# A string or an array of strings is accepted.
+fonts = ["/path/to/FiraMath-Regular.otf", "/path/to/fonts"]
+
+# Search platform system-font directories. Defaults to true.
+# Embedded fallback fonts remain available when the binary is built with the
+# default `embed-fonts` Cargo feature.
+include_system_fonts = true
 
 # Preamble to be added before the typst code
 #

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -23,6 +23,7 @@ use typst::{
     utils::LazyHash,
     Library, LibraryExt, World, WorldExt,
 };
+use typst_kit::fonts::FontSlot;
 use typst_svg::svg;
 
 /// Errors that can occur during Typst compilation.
@@ -57,6 +58,23 @@ struct CachedFile {
     source: Option<Source>,
 }
 
+/// A font supplied either by typst-kit's lazy search or as an explicit file.
+pub enum FontSource {
+    /// A font loaded on first use.
+    Lazy(FontSlot),
+    /// An explicitly configured font file, parsed during initialization.
+    Loaded(Font),
+}
+
+impl FontSource {
+    fn get(&self) -> Option<Font> {
+        match self {
+            Self::Lazy(slot) => slot.get(),
+            Self::Loaded(font) => Some(font.clone()),
+        }
+    }
+}
+
 /// The Typst compiler context.
 ///
 /// This struct holds all the state needed to compile Typst documents:
@@ -76,8 +94,8 @@ pub struct Compiler {
     pub library: LazyHash<Library>,
     /// Font metadata book for font selection.
     pub book: LazyHash<FontBook>,
-    /// Loaded font data.
-    pub fonts: Vec<Font>,
+    /// Configured fonts and lazy slots in the same order as `book`.
+    pub fonts: Vec<FontSource>,
     /// Cache directory for downloaded packages.
     pub cache: PathBuf,
     /// Internal file cache for sources and binary files.
@@ -380,7 +398,7 @@ impl World for WrapSource<'_> {
     }
 
     fn font(&self, index: usize) -> Option<Font> {
-        self.compiler.fonts.get(index).cloned()
+        self.compiler.fonts.get(index)?.get()
     }
 
     fn today(&self, _offset: Option<i64>) -> Option<Datetime> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@
 //! - `preamble`: Typst code to prepend to all math blocks
 //! - `inline_preamble`: Typst code to prepend to inline math blocks
 //! - `display_preamble`: Typst code to prepend to display math blocks
-//! - `fonts`: List of font directories to load
+//! - `fonts`: List of font files or directories to load
+//! - `include_system_fonts`: Search system font directories (default: `true`)
 //! - `cache`: Directory for caching downloaded packages
 //! - `color_mode`: Color mode for SVG output (`auto` or `static`)
 //! - `code_tag`: Language tag for code blocks to render as Typst (default: `typst,render`)
@@ -34,9 +35,10 @@ use mdbook_preprocessor::{Preprocessor, PreprocessorContext};
 use serde::Deserialize;
 
 mod compiler;
-use compiler::{CompileError, Compiler};
+use compiler::{CompileError, Compiler, FontSource};
 use typst::foundations::Bytes;
-use typst::text::{Font, FontInfo};
+use typst::text::{Font, FontBook};
+use typst_kit::fonts::FontSearcher;
 
 /// Options that control how Typst renders math blocks.
 ///
@@ -110,6 +112,22 @@ impl FontsConfig {
     }
 }
 
+fn extend_searched_fonts(
+    book: &mut FontBook,
+    fonts: &mut Vec<FontSource>,
+    searched: typst_kit::fonts::Fonts,
+) {
+    for (index, slot) in searched.fonts.into_iter().enumerate() {
+        let info = searched
+            .book
+            .info(index)
+            .expect("font book and slots must have matching indices")
+            .clone();
+        book.push(info);
+        fonts.push(FontSource::Lazy(slot));
+    }
+}
+
 /// Configuration for the typst-math preprocessor from book.toml
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
@@ -123,8 +141,11 @@ struct TypstMathConfig {
     /// Optional preamble for display math blocks.
     display_preamble: Option<String>,
 
-    /// Custom fonts to load
+    /// Custom font files or directories to load.
     fonts: Option<FontsConfig>,
+
+    /// Whether to search system font directories. Defaults to true.
+    include_system_fonts: Option<bool>,
 
     /// Cache directory for downloaded packages
     cache: Option<String>,
@@ -190,70 +211,53 @@ impl Preprocessor for TypstProcessor {
             enable_code: config.enable_code.unwrap_or(true),
         };
 
-        let mut db = fontdb::Database::new();
-        // Load fonts from the config
+        let mut font_book = FontBook::new();
+        let mut font_sources = Vec::new();
+
+        // Keep configured paths in priority order. Explicit files are expected
+        // to be few and remain eagerly parsed; directories use lazy slots.
         if let Some(fonts) = config.fonts {
             for font_path in fonts.into_vec() {
                 let path = std::path::Path::new(&font_path);
                 if path.is_file() {
-                    // Load single font file
-                    if let Err(e) = db.load_font_file(&font_path) {
-                        eprintln!("Warning: Failed to load font file {:?}: {}", font_path, e);
+                    match std::fs::read(path) {
+                        Ok(data) => {
+                            let before = font_sources.len();
+                            for font in Font::iter(Bytes::new(data)) {
+                                font_book.push(font.info().clone());
+                                font_sources.push(FontSource::Loaded(font));
+                            }
+                            if font_sources.len() == before {
+                                eprintln!("Warning: Failed to parse font file {:?}", font_path);
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Warning: Failed to load font file {:?}: {}", font_path, e);
+                        }
                     }
                 } else if path.is_dir() {
-                    // Load all fonts from directory
-                    db.load_fonts_dir(&font_path);
+                    let mut searcher = FontSearcher::new();
+                    searcher.include_system_fonts(false);
+                    #[cfg(feature = "embed-fonts")]
+                    searcher.include_embedded_fonts(false);
+                    extend_searched_fonts(
+                        &mut font_book,
+                        &mut font_sources,
+                        searcher.search_with([path]),
+                    );
                 } else {
                     eprintln!("Warning: Font path does not exist: {:?}", font_path);
                 }
             }
         }
-        // Load system fonts, lower priority
-        db.load_system_fonts();
 
-        // Add all fonts in db to the compiler
-        for face in db.faces() {
-            let Some(info) = db.with_face_data(face.id, FontInfo::new).flatten() else {
-                eprintln!(
-                    "Warning: Failed to load font info for {:?}, skipping",
-                    face.source
-                );
-                continue;
-            };
-            compiler.book.push(info);
-            let font = match &face.source {
-                fontdb::Source::File(path) | fontdb::Source::SharedFile(path, _) => {
-                    match std::fs::read(path) {
-                        Ok(bytes) => Font::new(Bytes::new(bytes), face.index),
-                        Err(e) => {
-                            eprintln!(
-                                "Warning: Failed to read font file {:?}: {}, skipping",
-                                path, e
-                            );
-                            continue;
-                        }
-                    }
-                }
-                fontdb::Source::Binary(data) => {
-                    Font::new(Bytes::new(data.as_ref().as_ref().to_vec()), face.index)
-                }
-            };
-            if let Some(font) = font {
-                compiler.fonts.push(font);
-            }
-        }
+        // System and embedded fonts have lower priority than configured paths.
+        let mut searcher = FontSearcher::new();
+        searcher.include_system_fonts(config.include_system_fonts.unwrap_or(true));
+        extend_searched_fonts(&mut font_book, &mut font_sources, searcher.search());
 
-        #[cfg(feature = "embed-fonts")]
-        {
-            // Load typst embedded fonts, lowest priority
-            for data in typst_assets::fonts() {
-                let buffer = Bytes::new(data);
-                for font in Font::iter(buffer) {
-                    compiler.book.push(font.info().clone());
-                    compiler.fonts.push(font);
-                }
-            }
-        }
+        compiler.book = typst::utils::LazyHash::new(font_book);
+        compiler.fonts = font_sources;
 
         // Set the cache dir
         if let Some(ref cache) = config.cache {


### PR DESCRIPTION
> This pull request was developed with assistance from GPT-5.6-sol.

Closes: #70

## Problem

Font discovery currently materializes every discovered font during startup:

```rust
db.load_system_fonts();

for face in db.faces() {
    compiler.book.push(info);
    let font = std::fs::read(path)
        .ok()
        .and_then(|bytes| Font::new(Bytes::new(bytes), face.index));
    compiler.fonts.push(font);
}
```

Embedded fallback fonts are loaded eagerly as well. This makes startup memory scale with the complete system font collection rather than the fonts actually used by the document. On systems with many fonts, even a book without math can consume several gigabytes during preprocessing.

## Summary

This PR replaces eager system and directory font loading with `typst-kit`'s lazy font infrastructure.

- use `typst_kit::fonts::FontSearcher` for font discovery
- retain discovered fonts as lazy `FontSlot`s
- load font data only when Typst selects a font
- preserve explicitly configured font-file support and configured path priority
- route embedded fallback fonts through `typst-kit/embed-fonts`
- add an option to disable system font discovery

## Implementation

### Lazy font sources

`Compiler::fonts` previously stored fully parsed fonts:

```rust
pub fonts: Vec<Font>,
```

It now stores either a lazy slot or an explicitly loaded font:

```rust
pub enum FontSource {
    Lazy(FontSlot),
    Loaded(Font),
}

impl FontSource {
    fn get(&self) -> Option<Font> {
        match self {
            Self::Lazy(slot) => slot.get(),
            Self::Loaded(font) => Some(font.clone()),
        }
    }
}
```

Typst resolves the font through `World::font` only when it is selected:

```rust
fn font(&self, index: usize) -> Option<Font> {
    self.compiler.fonts.get(index)?.get()
}
```

`FontBook` retains the metadata required for selection, while the aligned `FontSource` entry retains the lazy loader. This avoids reading and parsing unused font files.

### Discovery order

Font sources remain ordered as follows:

1. explicitly configured font files and directories
2. system fonts, when enabled
3. embedded fallback fonts

Configured paths are processed separately to preserve their order and priority. Explicit font files remain eagerly parsed because they are intentionally selected and typically few. Directory, system, and embedded fonts use lazy slots.

### Dependency changes

Direct `fontdb` and `typst-assets` dependencies are replaced with:

```toml
typst-kit = { version = "0.14.2", default-features = false, features = ["fonts"] }

[features]
default = ["embed-fonts"]
embed-fonts = ["typst-kit/embed-fonts"]
```

This delegates font discovery, metadata indexing, lazy loading, and embedded-font integration to Typst's shared tooling.

## Configuration

The existing `fonts` option supports both individual files and directories:

```toml
[preprocessor.typst-math]
command = "mdbook-typst-math"
fonts = [
    "./fonts/MyFont.ttf",
    "./fonts",
]
```

System font discovery can now be disabled:

```toml
[preprocessor.typst-math]
include_system_fonts = false
```

`include_system_fonts` defaults to `true`, preserving existing behavior. The README also corrects the preprocessor section name from `[preprocessor.typst]` to `[preprocessor.typst-math]`.

## Performance

Measured with release builds and a warm filesystem cache while processing a minimal mdBook without formulas on a system with 891 discovered font faces:

| | Current `main` | This PR |
|---|---:|---:|
| Peak RSS | 7,238,184 KiB | 43,700 KiB |
| Wall time | 2.74 s | 0.49 s |

In this environment, peak RSS decreased from approximately 6.90 GiB to 42.7 MiB (about 99.4%), and startup was approximately 5.6× faster.

Exact results depend on the installed fonts and the fonts selected by a document. Required fonts are still loaded during rendering; unused fonts remain unloaded.

## Compatibility

- system font discovery remains enabled by default
- embedded fallback fonts remain enabled by the default Cargo feature
- configured font files and directories remain supported
- configured path order remains significant
- no book-side math syntax changes are required

## Validation

- `cargo fmt`
- `cargo check`
- `cargo check --no-default-features`
- `cargo test`
- release build
- minimal mdBook build with default font discovery
- minimal mdBook build with an explicitly configured `.ttf` file
